### PR TITLE
EditorConfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+charset = utf-8
+indent_style = space
+indent_size = 2
+end_of_line = lf
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false


### PR DESCRIPTION
## コーディングスタイルを統一するためのツールの導入

EditorConfigは、異なるエディターやIDE間で一貫したコーディングスタイルを維持するためのツール。  
これにより、複数人での開発時にもコードの書式が統一され、可読性やメンテナンス性が向上

![Screenshot 2023-04-28 at 15 38 24](https://user-images.githubusercontent.com/24947347/235073011-8e44d1ff-5455-413a-bc4e-4bbbfd0549ba.png)

<p style="box-sizing: border-box; border: 0px solid rgb(217, 217, 227); --tw-border-spacing-x:0; --tw-border-spacing-y:0; --tw-translate-x:0; --tw-translate-y:0; --tw-rotate:0; --tw-skew-x:0; --tw-skew-y:0; --tw-scale-x:1; --tw-scale-y:1; --tw-pan-x: ; --tw-pan-y: ; --tw-pinch-zoom: ; --tw-scroll-snap-strictness:proximity; --tw-ordinal: ; --tw-slashed-zero: ; --tw-numeric-figure: ; --tw-numeric-spacing: ; --tw-numeric-fraction: ; --tw-ring-inset: ; --tw-ring-offset-width:0px; --tw-ring-offset-color:#fff; --tw-ring-color:rgba(59,130,246,0.5); --tw-ring-offset-shadow:0 0 transparent; --tw-ring-shadow:0 0 transparent; --tw-shadow:0 0 transparent; --tw-shadow-colored:0 0 transparent; --tw-blur: ; --tw-brightness: ; --tw-contrast: ; --tw-grayscale: ; --tw-hue-rotate: ; --tw-invert: ; --tw-saturate: ; --tw-sepia: ; --tw-drop-shadow: ; --tw-backdrop-blur: ; --tw-backdrop-brightness: ; --tw-backdrop-contrast: ; --tw-backdrop-grayscale: ; --tw-backdrop-hue-rotate: ; --tw-backdrop-invert: ; --tw-backdrop-opacity: ; --tw-backdrop-saturate: ; --tw-backdrop-sepia: ; margin: 1.25em 0px; color: rgb(209, 213, 219); font-family: Söhne, ui-sans-serif, system-ui, -apple-system, &quot;Segoe UI&quot;, Roboto, Ubuntu, Cantarell, &quot;Noto Sans&quot;, sans-serif, &quot;Helvetica Neue&quot;, Arial, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;, &quot;Segoe UI Symbol&quot;, &quot;Noto Color Emoji&quot;; font-size: 16px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: pre-wrap; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(68, 70, 84); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><code style="box-sizing: border-box; border: 0px solid rgb(217, 217, 227); --tw-border-spacing-x:0; --tw-border-spacing-y:0; --tw-translate-x:0; --tw-translate-y:0; --tw-rotate:0; --tw-skew-x:0; --tw-skew-y:0; --tw-scale-x:1; --tw-scale-y:1; --tw-pan-x: ; --tw-pan-y: ; --tw-pinch-zoom: ; --tw-scroll-snap-strictness:proximity; --tw-ordinal: ; --tw-slashed-zero: ; --tw-numeric-figure: ; --tw-numeric-spacing: ; --tw-numeric-fraction: ; --tw-ring-inset: ; --tw-ring-offset-width:0px; --tw-ring-offset-color:#fff; --tw-ring-color:rgba(59,130,246,0.5); --tw-ring-offset-shadow:0 0 transparent; --tw-ring-shadow:0 0 transparent; --tw-shadow:0 0 transparent; --tw-shadow-colored:0 0 transparent; --tw-blur: ; --tw-brightness: ; --tw-contrast: ; --tw-grayscale: ; --tw-hue-rotate: ; --tw-invert: ; --tw-saturate: ; --tw-sepia: ; --tw-drop-shadow: ; --tw-backdrop-blur: ; --tw-backdrop-brightness: ; --tw-backdrop-contrast: ; --tw-backdrop-grayscale: ; --tw-backdrop-hue-rotate: ; --tw-backdrop-invert: ; --tw-backdrop-opacity: ; --tw-backdrop-saturate: ; --tw-backdrop-sepia: ; font-family: &quot;Söhne Mono&quot;, Monaco, &quot;Andale Mono&quot;, &quot;Ubuntu Mono&quot;, monospace !important; font-size: 0.875em; color: var(--tw-prose-code); font-weight: 600;">.editorconfig</code>ファイル:</p>

プロパティ | 説明
-- | --
root | このファイルがプロジェクトの最上位のEditorConfigファイルであることを示します。
indent_style | インデントスタイルを指定します。"space"（スペース）または"tab"（タブ）を選択できます。
indent_size | インデントサイズを指定します。整数値で指定します。
end_of_line | 改行コードを指定します。"lf"（Unixスタイル）, "crlf"（Windowsスタイル）などがあります。
charset | 文字コードを指定します。"utf-8", "utf-16le", "utf-16be", "latin1" などがあります。
trim_trailing_whitespace | 行末の余分な空白文字を削除するかどうかを指定します。trueまたはfalseを選択できます。
insert_final_newline | ファイルの最後に改行を挿入するかどうかを指定します。trueまたはfalseを選択できます。

<br class="Apple-interchange-newline">


## Prettierとの組み合わせ

Prettierは、より詳細なスタイル設定や自動整形機能を提供するコードフォーマッター。
実際には、EditorConfigとPrettierを組み合わせて使うことで、最も効果的なコーディングスタイルの統一が実現可能。
EditorConfigで基本的なスタイルを設定し、Prettierで詳細な整形ルールを適用するという方法が一般的

※ 既にに`.prettierrrs.json`ファイルがありますが、まだ使っていない方は設定をお願いします

特定のプロジェクトのみにPrettierをデフォルトのフォーマッターとして適用する場合、次の手順で行うことができます。

1. VSCodeを開きます。
2. ⌘+Shift+P を押して、コマンドパレットを開きます。
3. コマンドパレットに "Preferences: WorkSpace Settings (JSON)" と入力し、表示される候補から選択してEnterキーを押します。これにより、.vscodeディレクトリ内にsettings.jsonファイルが生成されます。
4. settings.jsonファイルに以下の設定を追加して、Prettierをデフォルトのフォーマッターに設定します。

```
"editor.defaultFormatter": "esbenp.prettier-vscode",
"editor.formatOnSave": true,
"editor.codeActionsOnSave": {
  "source.fixAll": true
}
```
設定を保存して、VSCodeを再起動してください。


